### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2020-07-07
+
+**Changed**: 
+- Renamed observable collections getters to properties
+- Now the observable collections don't take the collection reference directly in the constructor but rather the lambda to get it. This allows for async setups with observable collections.
+
 ## [0.8.1] - 2020-07-07
 
 - Added implicit operator to convert *ObservableField* to it's defined generic type

--- a/Runtime/ObservableList.cs
+++ b/Runtime/ObservableList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 // ReSharper disable once CheckNamespace
@@ -10,7 +11,7 @@ namespace GameLovers
 	/// </remarks>
 	public class ObservableList<T> : IdList<int, T> where T : struct
 	{
-		public ObservableList(IList<T> list) : base(list.IndexOf, list)
+		public ObservableList(Func<IList<T>> listResolver) : base(value => listResolver().IndexOf(value), listResolver)
 		{
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.gamelovers.configscontainer",
   "displayName": "Configs Container",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "unity": "2019.3",
   "description": "This package helps with persistently maintain the static config data inside a ScriptableObject in the project.\nIt also provides with data type containers to store game data.",
   "type": "library",


### PR DESCRIPTION
**Changed**:
- Renamed observable collections getters to properties
- Now the observable collections don't take the collection reference directly in the constructor but rather the lambda to get it. This allows for async setups with observable collections.